### PR TITLE
fix:お店の候補がない場合は「送信」ボタンを表示しないように変更

### DIFF
--- a/app/views/votes/new.html.erb
+++ b/app/views/votes/new.html.erb
@@ -7,14 +7,23 @@
       <%= link_to "トップページへ", group_path(@group), class: "btn btn-sm bg-stone-400 hover:bg-stone-500 text-white rounded-full" %>
     </div>
 
-    <%= form_with url: group_votes_path(@group), method: :post, local: true,data: { turbo: false } do %>
-      <% @shops.each do |shop| %>
-        <%= render partial: "vote_card", locals: { shop: shop } %>
-      <% end %>
-      <!-- Submit Button -->
-      <div class="flex justify-center">
-        <%= submit_tag "送信", class: "btn btn-wide btn-primary rounded-full text-lg" %>
+    <% if @shops.empty? %>
+      <div role="alert" class="alert alert-warning">
+        <svg xmlns="http://www.w3.org/2000/svg" class="h-6 w-6 shrink-0 stroke-current" fill="none" viewBox="0 0 24 24">
+          <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M12 9v2m0 4h.01m-6.938 4h13.856c1.54 0 2.502-1.667 1.732-3L13.732 4c-.77-1.333-2.694-1.333-3.464 0L3.34 16c-.77 1.333.192 3 1.732 3z" />
+        </svg>
+        <span>お店候補を登録してください。</span>
       </div>
+    <% else %>
+      <%= form_with url: group_votes_path(@group), method: :post, local: true,data: { turbo: false } do %>
+        <% @shops.each do |shop| %>
+          <%= render partial: "vote_card", locals: { shop: shop } %>
+        <% end %>
+        <!-- Submit Button -->
+        <div class="flex justify-center">
+          <%= submit_tag "送信", class: "btn btn-wide btn-primary rounded-full text-lg" %>
+        </div>
+      <% end %>
     <% end %>
   </div>
 </div>


### PR DESCRIPTION
## 概要
投票画面のボタン表示制御
CLOSES #72  

### 作業内容
- お店の候補がない場合は「送信」ボタンを表示しないように変更
- 
### 作業結果
-お店の候補がない場合は「送信」ボタンが表示されていないことを確認

### 備考
