### PR TITLE
add:店舗登録時のバリデーションを追加

### DIFF
--- a/app/models/shop.rb
+++ b/app/models/shop.rb
@@ -1,4 +1,7 @@
 class Shop < ApplicationRecord
+  validates :name, presence: true
+  validates :address, presence: true
+
   belongs_to :group
 
   has_many :votes, dependent: :destroy

--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,0 +1,10 @@
+ <% if object.errors.any? %>
+    <div class="mb-6 p-4 bg-red-100 text-red-700 rounded-lg">
+    <h3 class="font-bold mb-2"><%= object.errors.count %> 件のエラーがあります:</h3>
+    <ul class="list-disc pl-5">
+        <% object.errors.full_messages.each do |msg| %>
+        <li><%= msg %></li>
+        <% end %>
+    </ul>
+    </div>
+<% end %>

--- a/app/views/shops/new.html.erb
+++ b/app/views/shops/new.html.erb
@@ -1,5 +1,6 @@
 <body class="bg-base-200 min-h-screen">
   <main class="container mx-auto px-4 py-6 max-w-md">
+    <%= render 'shared/error_messages', object: @shop%>
     <%# TODO:店舗名、住所、自動入力対応 %>
     <!-- フォーム本体 -->
     <div class="card bg-base-100 shadow-md rounded-2xl">


### PR DESCRIPTION
## 概要
お店登録時の簡易バリデーション追加
CLOSES #71  

### 作業内容
- shopにバリデーションを追加
- エラーメッセージの共通レイアウトを作成
- 店舗登録画面にエラーメッセージを追加

### 作業結果
- 店舗登録時にバリデーションにひっかかったらエラーメッセージが出るようになった

### 備考
